### PR TITLE
Refactor layout into reusable components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,121 +14,13 @@ import {
   MessageSquare,
   Award,
   Calendar,
-  Download,
   ExternalLink,
 } from 'lucide-react';
-import CountUp from 'react-countup';
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
-import L from 'leaflet';
 
-// Import Leaflet CSS
-import 'leaflet/dist/leaflet.css';
+import StatsSection from './components/StatsSection';
+import MapSection from './components/MapSection';
+import ResumeDownload from './components/ResumeDownload';
 
-// Import local marker images to avoid external fetches
-import markerIcon from './assets/leaflet/marker-icon.png';
-import markerIcon2x from './assets/leaflet/marker-icon-2x.png';
-import markerShadow from './assets/leaflet/marker-shadow.png';
-
-// Fix Leaflet's default icon paths to use local images
-delete L.Icon.Default.prototype._getIconUrl;
-L.Icon.Default.mergeOptions({
-  iconUrl: markerIcon,
-  iconRetinaUrl: markerIcon2x,
-  shadowUrl: markerShadow,
-});
-
-/**
- * StatsSection
- * Displays animated counters for key statistics from the CV.
- */
-const StatsSection = () => {
-  const stats = [
-    { label: 'Years Experience', value: 5 },
-    { label: 'Features Launched', value: 15 },
-    { label: 'Teams Led', value: 3 },
-    { label: 'Countries Worked', value: 4 },
-  ];
-  return (
-    <section id="stats" className="relative z-10 py-20 px-6 bg-black/20">
-      <div className="max-w-6xl mx-auto">
-        <h2 className="text-4xl md:text-5xl font-bold text-center mb-16 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
-          Stats
-        </h2>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-          {stats.map((stat, index) => (
-            <div
-              key={index}
-              className="bg-white/5 backdrop-blur-lg rounded-2xl p-8 border border-white/10 flex flex-col items-center justify-center"
-            >
-              <div className="text-5xl font-bold text-blue-400 mb-4">
-                <CountUp end={stat.value} duration={2} />
-              </div>
-              <div className="text-lg text-gray-300 text-center">
-                {stat.label}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-};
-
-/**
- * MapSection
- * Displays work locations on an interactive map using Leaflet.
- */
-const MapSection = () => {
-  const positions = [
-    { name: 'Munich', coords: [48.1351, 11.5820] },
-    { name: 'Berlin', coords: [52.5200, 13.4050] },
-    { name: 'Istanbul', coords: [41.0082, 28.9784] },
-    { name: 'Dusseldorf', coords: [51.2277, 6.7735] },
-  ];
-  // Choose a center roughly between the markers
-  const center = [50.1109, 8.6821];
-  return (
-    <section id="locations" className="relative z-10 py-20 px-6">
-      <div className="max-w-6xl mx-auto">
-        <h2 className="text-4xl md:text-5xl font-bold text-center mb-16 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
-          Locations
-        </h2>
-        <div className="h-96 w-full rounded-2xl overflow-hidden border border-white/10">
-          <MapContainer center={center} zoom={5} style={{ height: '100%', width: '100%' }}>
-            <TileLayer
-              attribution='&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
-              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-            />
-            {positions.map((pos, idx) => (
-              <Marker key={idx} position={pos.coords}>
-                <Popup>{pos.name}</Popup>
-              </Marker>
-            ))}
-          </MapContainer>
-        </div>
-      </div>
-    </section>
-  );
-};
-
-/**
- * ResumeDownload
- * Provides a button linking to the PDF CV.
- */
-const ResumeDownload = () => {
-  return (
-    <div className="text-center py-12">
-      <a
-        href="/cem_kilic_cv.pdf"
-        download
-        className="group border border-white/20 px-6 py-3 rounded-full font-medium transition-all duration-300 hover:bg-white/10 hover:border-white/40 flex items-center gap-2 mx-auto"
-      >
-        <Download className="w-4 h-4" />
-        Download Resume
-      </a>
-    </div>
-  );
-};
 
 /**
  * Main portfolio component

--- a/src/components/MapSection.jsx
+++ b/src/components/MapSection.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+// Import local marker images to avoid external fetches
+import markerIcon from '../assets/leaflet/marker-icon.png';
+import markerIcon2x from '../assets/leaflet/marker-icon-2x.png';
+import markerShadow from '../assets/leaflet/marker-shadow.png';
+
+// Fix Leaflet's default icon paths to use local images
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow,
+});
+
+/**
+ * MapSection
+ * Displays work locations on an interactive map using Leaflet.
+ */
+const MapSection = () => {
+  const positions = [
+    { name: 'Munich', coords: [48.1351, 11.5820] },
+    { name: 'Berlin', coords: [52.5200, 13.4050] },
+    { name: 'Istanbul', coords: [41.0082, 28.9784] },
+    { name: 'Dusseldorf', coords: [51.2277, 6.7735] },
+  ];
+
+  // Choose a center roughly between the markers
+  const center = [50.1109, 8.6821];
+
+  return (
+    <section id="locations" className="relative z-10 py-20 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-4xl md:text-5xl font-bold text-center mb-16 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+          Locations
+        </h2>
+        <div className="h-96 w-full rounded-2xl overflow-hidden border border-white/10">
+          <MapContainer center={center} zoom={5} style={{ height: '100%', width: '100%' }}>
+            <TileLayer
+              attribution='&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+            {positions.map((pos, idx) => (
+              <Marker key={idx} position={pos.coords}>
+                <Popup>{pos.name}</Popup>
+              </Marker>
+            ))}
+          </MapContainer>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MapSection;

--- a/src/components/ResumeDownload.jsx
+++ b/src/components/ResumeDownload.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Download } from 'lucide-react';
+
+/**
+ * ResumeDownload
+ * Provides a button linking to the PDF CV.
+ */
+const ResumeDownload = () => {
+  return (
+    <div className="text-center py-12">
+      <a
+        href="/cem_kilic_cv.pdf"
+        download
+        className="group border border-white/20 px-6 py-3 rounded-full font-medium transition-all duration-300 hover:bg-white/10 hover:border-white/40 flex items-center gap-2 mx-auto"
+      >
+        <Download className="w-4 h-4" />
+        Download Resume
+      </a>
+    </div>
+  );
+};
+
+export default ResumeDownload;

--- a/src/components/StatsSection.jsx
+++ b/src/components/StatsSection.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import CountUp from 'react-countup';
+
+/**
+ * StatsSection
+ * Displays animated counters for key statistics from the CV.
+ */
+const StatsSection = () => {
+  const stats = [
+    { label: 'Years Experience', value: 5 },
+    { label: 'Features Launched', value: 15 },
+    { label: 'Teams Led', value: 3 },
+    { label: 'Countries Worked', value: 4 },
+  ];
+
+  return (
+    <section id="stats" className="relative z-10 py-20 px-6 bg-black/20">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-4xl md:text-5xl font-bold text-center mb-16 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+          Stats
+        </h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
+          {stats.map((stat, index) => (
+            <div
+              key={index}
+              className="bg-white/5 backdrop-blur-lg rounded-2xl p-8 border border-white/10 flex flex-col items-center justify-center"
+            >
+              <div className="text-5xl font-bold text-blue-400 mb-4">
+                <CountUp end={stat.value} duration={2} />
+              </div>
+              <div className="text-lg text-gray-300 text-center">
+                {stat.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default StatsSection;


### PR DESCRIPTION
## Summary
- extract Stats, Map, and Resume download sections into dedicated components
- streamline App layout by importing the new components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68951aed70c8832da9dbb04e97f996d9